### PR TITLE
readme: fix refs to S7seg-apps

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,10 +10,6 @@
 	path = tools/vtr-verilog-to-routing
 	url = https://github.com/SymbiFlow/vtr-verilog-to-routing
 	branch = master
-[submodule "tools/-f"]
-	path = tools/-f
-	url = https://github.com/QuickLogic-Corp/quicklogic-fasm
-	branch = master
 [submodule "tools/quicklogic-fasm"]
 	path = tools/quicklogic-fasm
 	url = https://github.com/QuickLogic-Corp/quicklogic-fasm

--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ The SDK will mention about setup instructions of the Toolchain and utilties, whi
 
 ## Examples
 
-Few FPGA examples are available in this folder for 7 segment and LED blink which can be compiled to bin.
+Few FPGA examples are available in [pygmy-sdk/S7seg-apps/](pygmy-sdk/S7seg-apps) for 7 segment and LED blink. Those can be synthesized/compiled to bitstreams (bin files).
 
 ```sh
 # Example 1
-cd S7seg-apps/static-number
+cd static-number
 ql_symbiflow -compile -src . -d ql-eos-s3 \
   -t top \
   -v blinky.v \
@@ -30,7 +30,7 @@ ql_symbiflow -compile -src . -d ql-eos-s3 \
 
 ```sh
 # Example 2
-cd S7seg-apps/blinky
+cd blinky
 ql_symbiflow -compile -src . -d ql-eos-s3 \
   -t helloworldfpga \
   -v blinky.v \

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ cd pygmy-dev
 
 Follow the readme in tools to setup the tools for Pygmy board to setup the tools (one time).
 
-Please refer to https://github.com/QuickLogic-Corp/TinyFPGA-Programmer-Application document, to install serial driver and FPGA programmer application.
+Please refer to [QuickLogic-Corp/TinyFPGA-Programmer-Application](https://github.com/QuickLogic-Corp/TinyFPGA-Programmer-Application) document, for installing serial drivers and the FPGA programmer application.
 
-The source code is within pygmy-sdk clone from qorc-sdk.
+The source code is within submodule `pygmy-sdk` (a fork of [QuickLogic-Corp/qorc-sdk](https://github.com/QuickLogic-Corp/qorc-sdk)).
 
 The SDK will mention about setup instructions of the Toolchain and utilties, which you need to IGNORE, as they are applicable to Linux x86-64 machines only. You can follow the instructions from  the "Baremetal Example" section of Readme.
 


### PR DESCRIPTION
On the one hand, some minor fixes are done in the README, to match https://github.com/optimuslogic/pygmy-dev/commit/64e3e65c4ed514f29f2fcda76e02148621f80928.

On the other hand, it seems that one of the submodules in `.gitmodules` is incorrect (and ignored). It's removed here.